### PR TITLE
Migrate from master/slave terminology

### DIFF
--- a/src/trex.py
+++ b/src/trex.py
@@ -59,7 +59,7 @@ def __trex_reset():
     trex_packet[21] = 50  # Impact sensitivity low byte
     trex_packet[22] = 840   # Battery voltage high byte
     trex_packet[23] = 600  # Battery voltage low byte
-    trex_packet[24] = 7   # I2C slave address
+    trex_packet[24] = 7   # I2C subordinate address
     trex_packet[25] = 0   # I2C clock frequency
 
 __trex_reset()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.